### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "clipboard": "^2.0.4",
     "core-js": "^2.6.5",
     "gatsby": "^2.8.5",
-    "npm": "^6.9.0",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-helmet": "^5.2.0",


### PR DESCRIPTION

Hello MohammedEssehemy!

It seems like you have npm as one of your (dev-) dependency in essehemy.me.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
